### PR TITLE
Reduce crate size by adding 'include' directive to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ name                                    = "boolector-sys"
 readme                                  = "README.md"
 repository                              = "https://github.com/fatemender/boolector-sys"
 version                                 = "0.3.1"
+include = ["src/lib.rs", "LICENSE", "README.md", "build.rs", "src-generated/*", "boolector/src/*"]
 
 [dependencies]
 libc                                    = "0.2"


### PR DESCRIPTION
This is based on the output of `cargo diet`, bringing the crate size
down to 517kb.

Even though it builds fine, I am not sure if `cargo package` is
the best test to run against it to assure it's working correctly.